### PR TITLE
Change links from gitlab to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MARVIN-config
 
 MARVIN is the release bot that does automated DBpedia releases each month on three different servers for generic, mappings, wikidata, abstract extraction. 
-[This repository](https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config) can be used to fork the architecture for creating extensions, developing new extractors or debugging old ones. 
+[This repository](https://github.com/dbpedia/marvin-config) can be used to fork the architecture for creating extensions, developing new extractors or debugging old ones. 
 Fixes and patches will be deployed on the DBpedia servers each month via a fresh `git clone` from the `master` branch of the [DIEF (DBpedia Information Extraction Framework)](https://github.com/dbpedia/extraction-framework/). 
 
 ## Contributions & License
@@ -15,7 +15,7 @@ Implementation note: the scripts creates a folder `marvin-extraction` where the 
 
 ```
 # check out this repo with all config files
-git clone https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config
+git clone https://github.com/dbpedia/marvin-config
 cd marvin-config
 
 
@@ -78,7 +78,7 @@ If you want to adapt some paths you can edit them inside `fucntions.sh`.
 ./marvin-extraction-run.sh
 ```
 ### Post-Processing
-Some extractions require postprocessing. The exact setup can be found in [functions.sh](https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/functions.sh#L41)
+Some extractions require postprocessing. The exact setup can be found in [functions.sh](https://github.com/dbpedia/marvin-config/blob/35b1b6d5b85ca0e8d47bdf0dcd27356eca797483/functions.sh#L41)
 More info about [post-processing](http://dev.dbpedia.org/Post-Processing).
 
 ## Deploy MARVIN on Databus

--- a/dashboard/src/main/webapp/index.html
+++ b/dashboard/src/main/webapp/index.html
@@ -116,7 +116,7 @@
 									</p>
 									<!-- <h4>Configuration</h4> -->
 									<p>
-										The <strong>configuration of MARVIN is public available at </strong><a href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config">gitlab</a>.
+										The <strong>configuration of MARVIN is public available at </strong><a href="https://github.com/dbpedia/marvin-config">gitlab</a>.
 									Further information are described in <a href="https://svn.aksw.org/papers/2020/semantics_marvin/public.pdf">The New DBpedia Release Cycle: IncreasingAgility and Efficiency in Knowledge ExtractionWorkflows</a>.
 									</p>
 									<h4 class="text-danger">DISCLAIMER: The release depends on several external dependencies. Therefore we can not guarantee a full release every month.
@@ -206,9 +206,9 @@
 											<strong>Configuration:</strong>
 											<br>
 											View
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/download.mappings.properties">Download</a>,
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/extraction.mappings.properties">Extraction</a>,
-											<a target="_blank" href="#">https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/mappings</a>
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/download.mappings.properties">Download</a>,
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/extraction.mappings.properties">Extraction</a>,
+											<a target="_blank" href="#">https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/mappings</a>
 											configuration.
 										</p>
 										<p>
@@ -238,9 +238,9 @@
 											<strong>Configuration:</strong>
 											<br>
 											View
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/download.generic.properties">Download</a>,
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/extraction.generic.properties">Extraction</a>
-											<a target="_blank" href="#">https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/generic</a>
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/download.generic.properties">Download</a>,
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/extraction.generic.properties">Extraction</a>
+											<a target="_blank" href="#">https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/generic</a>
 											configuration.
 										</p>
 										<p>
@@ -270,9 +270,9 @@
 											<strong>Configuration:</strong>
 											<br>
 											View
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/download.wikidata.properties">Download</a>,
-											<a target="_blank" href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/blob/master/extractionConfiguration/extraction.wikidata.properties">Extraction</a>
-											<a target="_blank" href="#">https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/wikidata</a>
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/download.wikidata.properties">Download</a>,
+											<a target="_blank" href="https://github.com/dbpedia/marvin-config/blob/master/extractionConfiguration/extraction.wikidata.properties">Extraction</a>
+											<a target="_blank" href="#">https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/wikidata</a>
 											configuration.
 										</p>
 										<p>

--- a/dashboard/src/main/webapp/index.old.html
+++ b/dashboard/src/main/webapp/index.old.html
@@ -52,7 +52,7 @@
                 gives details.
             </li>
             <li>The configuration of MARVIN is available in this <a
-                    href="https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config">public, read-only git
+                    href="https://github.com/dbpedia/marvin-config">public, read-only git
                 repo</a></li>
             <li>The cronjobs run on different servers on the 10th of each month, downloading the Wikimedia dumps from
                 the first of each month.

--- a/databus-poms/dbpedia/generic/pom.xml
+++ b/databus-poms/dbpedia/generic/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <databus.codeReference>https://github.com/dbpedia/extraction-framework/blob/master/core/src/main/scala/org/dbpedia/extraction/mappings/</databus.codeReference>
         <databus.issueTracker>https://github.com/dbpedia/extraction-framework/issues</databus.issueTracker>
-        <databus.documentationLocation>https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
+        <databus.documentationLocation>https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
         <databus.feedbackChannel>https://forum.dbpedia.org/c/data/databus/14</databus.feedbackChannel>
         <databus.tryVersionAsIssuedDate>true</databus.tryVersionAsIssuedDate>
         <databus.packageDirectory>${project.build.directory}/databus/repo/dbpedia/${project.groupId}/${project.artifactId}</databus.packageDirectory>

--- a/databus-poms/dbpedia/mappings/pom.xml
+++ b/databus-poms/dbpedia/mappings/pom.xml
@@ -60,7 +60,7 @@ For more technical information on how these datasets were generated, please visi
     <databus.license>http://purl.oclc.org/NET/rdflicense/cc-by3.0</databus.license>
     <databus.codeReference>https://github.com/dbpedia/extraction-framework/blob/master/core/src/main/scala/org/dbpedia/extraction/mappings/MappingExtractor.scala</databus.codeReference>
     <databus.issueTracker>https://github.com/dbpedia/extraction-framework/issues</databus.issueTracker>
-    <databus.documentationLocation>https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
+    <databus.documentationLocation>https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
     <databus.downloadUrlPath>https://downloads.dbpedia.org/repo/dbpedia/${project.groupId}/${project.artifactId}/${project.version}/</databus.downloadUrlPath>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <databus.packageDirectory>${project.build.directory}/databus/repo/dbpedia/${project.groupId}/${project.artifactId}</databus.packageDirectory>

--- a/databus-poms/dbpedia/text/pom.xml
+++ b/databus-poms/dbpedia/text/pom.xml
@@ -27,7 +27,7 @@
         <databus.codeReference>https://github.com/dbpedia/extraction-framework/blob/master/core/src/main/scala/org/dbpedia/extraction/mappings/HtmlAbstractExtractor.scala</databus.codeReference>
         <databus.issueTracker>https://github.com/dbpedia/extraction-framework/issues</databus.issueTracker>
         <databus.feedbackChannel>https://forum.dbpedia.org/c/data/databus/14</databus.feedbackChannel>
-        <databus.documentationLocation>https://git.informatik.uni-leipzig.de/dbpedia-assoc/marvin-config/-/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
+        <databus.documentationLocation>https://github.com/dbpedia/marvin-config/tree/master/databus-poms/dbpedia/${project.groupId}/${project.artifactId}</databus.documentationLocation>
         <databus.downloadUrlPath>https://downloads.dbpedia.org/repo/dbpedia/${project.groupId}/${project.artifactId}/${project.version}/</databus.downloadUrlPath>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <databus.packageDirectory>${project.build.directory}/databus/repo/dbpedia/${project.groupId}/${project.artifactId}</databus.packageDirectory>


### PR DESCRIPTION
I changed all links except one:
https://github.com/dbpedia/marvin-config/blob/35b1b6d5b85ca0e8d47bdf0dcd27356eca797483/dashboard/src/main/scala/org/dbpedia/release/Main.scala#L99 

I don't know what to do with it, because it is path to file in some folder, but it is also related to gitlab. So, should I also change it to github?