### PR TITLE
Removed redundant .RedirectExtractor entry from mappings config

### DIFF
--- a/extractionConfiguration/extraction.mappings.properties
+++ b/extractionConfiguration/extraction.mappings.properties
@@ -16,7 +16,7 @@ languages=@mappings
 
 # extractor class names starting with "." are prefixed by "org.dbpedia.extraction.mappings"
 
-extractors=.MappingExtractor,.RedirectExtractor
+#extractors=.MappingExtractor,.RedirectExtractor
 
 #extractors.ar=.MappingExtractor,.TopicalConceptsExtractor
 #


### PR DESCRIPTION
The .RedirectExtractor was already included in the generic config, making its presence in the mappings config redundant. This commit removes the redundant entry to streamline the configuration and avoid potential confusion.